### PR TITLE
Add legacy viewer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # streamlit-pdf-viewer
 
-Component allowing the visualisation and manipulation of PDF documents in streamlit 
+Component allowing the visualisation and manipulation of PDF documents in streamlit
 
 **Work in progress**
 
-We are early in the development, looking for contributors. 
-Currently, it has been tested on Chrome and Firefox.
+We are early in the development, looking for contributors. Currently, it has been tested on Chrome and Firefox.
 
 ![screenshot.png](docs/screenshot.png)
 
-You can see an [application](https://github.com/lfoppiano/structure-vision) in action [here](https://structure-vision.streamlit.app/). 
+You can see an [application](https://github.com/lfoppiano/structure-vision) in action [here](https://structure-vision.streamlit.app/).
 
 ## Getting started
 
@@ -17,7 +16,7 @@ You can see an [application](https://github.com/lfoppiano/structure-vision) in a
 pip install streamlit-pdf-viewer
 ```
 
-In your streamlit application, you can use it as: 
+In your streamlit application, you can use it as:
 
 ```python
 import streamlit as st
@@ -26,19 +25,33 @@ from streamlit_pdf_viewer import pdf_viewer
 pdf_viewer("str, path or bytes")
 ```
 
+## Options
 
+### Params
+
+In the following table the list of parameters that can be provided to the `pdf_viewer` function: 
+
+| name                    | description                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| input                   | The source of the PDF file. Accepts a file path, URL, or binary data.                                                                                                                                                                                                                                                                                                                                                         |
+| width                   | Width of the PDF viewer in pixels. Defaults to 700 pixels.                                                                                                                                                                                                                                                                                                                                                                    |
+| height                  | Height of the PDF viewer in pixels. If not provided, the viewer show the whole content.                                                                                                                                                                                                                                                                                                                                       |
+| annotations             | A list of annotations to be overlaid on the PDF. Each annotation should be a dictionary.                                                                                                                                                                                                                                                                                                                                      |
+| pages_vertical_spacing  | The vertical space (in pixels) between each page of the PDF. Defaults to 2 pixels.                                                                                                                                                                                                                                                                                                                                            |
+| annotation_outline_size | Size of the outline around each annotation in pixels. Defaults to 1 pixel.                                                                                                                                                                                                                                                                                                                                                    |
+| rendering               | Type of rendering. Default value "unwrap", which unwrap the PDF with pdf.js. Other values are "legacy_iframe" and "legacy_embed" which uses the legacy approach of injecting the document into an `<embed>` or `<iframe>`. These methods enable the default pdf viewer of Firefox/Chrome/Edge that contains additional features we are still working to implement for the "unwrap" method. |
 
 ## Developers notes
 
-### Environment 
+### Environment
+
 - Python >= 3.8
 - Node.js >= 16
 - Streamlit 1.28.2
 
 ### Configure environment for development
 
-First make sure that _RELEASE = False in `streamlit_pdf_viewer/__init__.py`. 
-To run the component in development mode, use the following commands:
+First make sure that _RELEASE = False in `streamlit_pdf_viewer/__init__.py`. To run the component in development mode, use the following commands:
 
 ```shell
 streamlit run my_component/__init__.py
@@ -47,12 +60,11 @@ cd frontend
 npm run serve
 ```
 
-These commands will start the Streamlit application and serve the Node.js component, respectively. 
-Ensure you're in the correct directory before running these commands.
+These commands will start the Streamlit application and serve the Node.js component, respectively. Ensure you're in the correct directory before running these commands.
 
 ### Integrate into a streamlit application
 
-1. Build the frontend part: 
+1. Build the frontend part:
 
     ```shell
     cd frontend
@@ -62,13 +74,13 @@ Ensure you're in the correct directory before running these commands.
 
 1. Make sure that _RELEASE = True in `streamlit_pdf_viewer/__init__.py`.
 
-2. move to the streamlit_application and run 
+2. move to the streamlit_application and run
 
     ```shell
     pip install -e {path of component}
     ```
 
-### Release 
+### Release
 
 ```shell 
 bump-my-version bump patch | minor | major

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ In the following table the list of parameters that can be provided to the `pdf_v
 | name                    | description                                                                                                                                                                                                                                                                                                                                                                                                                   |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | input                   | The source of the PDF file. Accepts a file path, URL, or binary data.                                                                                                                                                                                                                                                                                                                                                         |
-| width                   | Width of the PDF viewer in pixels. Defaults to 700 pixels.                                                                                                                                                                                                                                                                                                                                                                    |
-| height                  | Height of the PDF viewer in pixels. If not provided, the viewer show the whole content.                                                                                                                                                                                                                                                                                                                                       |
+| width                   | Width of the PDF viewer in pixels. It defaults to 700 pixels.                                                                                                                                                                                                                                                                                                                                                                    |
+| height                  | Height of the PDF viewer in pixels. If not provided, the viewer shows the whole content.                                                                                                                                                                                                                                                                                                                                       |
 | annotations             | A list of annotations to be overlaid on the PDF. Each annotation should be a dictionary.                                                                                                                                                                                                                                                                                                                                      |
 | pages_vertical_spacing  | The vertical space (in pixels) between each page of the PDF. Defaults to 2 pixels.                                                                                                                                                                                                                                                                                                                                            |
 | annotation_outline_size | Size of the outline around each annotation in pixels. Defaults to 1 pixel.                                                                                                                                                                                                                                                                                                                                                    |
-| rendering               | Type of rendering. Default value "unwrap", which unwrap the PDF with pdf.js. Other values are "legacy_iframe" and "legacy_embed" which uses the legacy approach of injecting the document into an `<embed>` or `<iframe>`. These methods enable the default pdf viewer of Firefox/Chrome/Edge that contains additional features we are still working to implement for the "unwrap" method. |
+| rendering               | Type of rendering. The default value "unwrap", which unwraps the PDF with pdf.js, and supports the visualisation of annotations. Other values are "legacy_iframe" and "legacy_embed" which use the legacy approach of injecting the document into an `<embed>` or `<iframe>`. These methods enable the default pdf viewer of Firefox/Chrome/Edge that contains additional features we are still working to implement for the "unwrap" method. **NOTE**: Annotations are ignored for both 'legacy_iframe' and 'legacy_embed'. |
 
 ## Developers notes
 
@@ -51,7 +51,7 @@ In the following table the list of parameters that can be provided to the `pdf_v
 
 ### Configure environment for development
 
-First make sure that _RELEASE = False in `streamlit_pdf_viewer/__init__.py`. To run the component in development mode, use the following commands:
+First, make sure that _RELEASE = False in `streamlit_pdf_viewer/__init__.py`. To run the component in development mode, use the following commands:
 
 ```shell
 streamlit run my_component/__init__.py
@@ -60,7 +60,7 @@ cd frontend
 npm run serve
 ```
 
-These commands will start the Streamlit application and serve the Node.js component, respectively. Ensure you're in the correct directory before running these commands.
+These commands will start the Streamlit application and serve the Node.js component. Please make sure you're in the correct directory before running these commands.
 
 ### Integrate into a streamlit application
 

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -6,7 +6,7 @@ from typing import Union
 import streamlit.components.v1 as components
 import json
 
-_RELEASE = True
+_RELEASE = False
 
 if not _RELEASE:
     _component_func = components.declare_component(
@@ -24,8 +24,9 @@ else:
 
 def pdf_viewer(input: Union[str, Path, bytes], width: int = 700, height: int = None, key=None,
                annotations=(),
-               pages_vertical_spacing=2,
-               annotation_outline_size=1
+               pages_vertical_spacing: int = 2,
+               annotation_outline_size: int = 1,
+               rendering: str = "unwrap"
                ):
     """
     pdf_viewer function to display a PDF file in a Streamlit app.
@@ -37,6 +38,10 @@ def pdf_viewer(input: Union[str, Path, bytes], width: int = 700, height: int = N
     :param annotations: A list of annotations to be overlaid on the PDF. Each annotation should be a dictionary.
     :param pages_vertical_spacing: The vertical space (in pixels) between each page of the PDF. Defaults to 2 pixels.
     :param annotation_outline_size: Size of the outline around each annotation in pixels. Defaults to 1 pixel.
+    :param rendering: Type of rendering. The default is "unwrap", which unwrap the PDF. Other values are
+    "legacy_iframe" and "legacy_embed" which uses the legacy approach for showing PDF document with streamlit.
+    These methods enable the default pdf viewer of Firefox/Chrome/Edge that contains additional features we are still
+    working to implement for the "unwrap" method.
 
     The function reads the PDF file (from a file path, URL, or binary data), encodes it in base64,
     and uses a Streamlit component to render it in the app. It supports optional annotations and adjustable margins.
@@ -57,9 +62,17 @@ def pdf_viewer(input: Union[str, Path, bytes], width: int = 700, height: int = N
         binary = input
 
     base64_pdf = base64.b64encode(binary).decode('utf-8')
-    component_value = _component_func(binary=base64_pdf, width=width, height=height, key=key, default=0,
-                                      annotations=annotations, pages_vertical_spacing=pages_vertical_spacing,
-                                      annotation_outline_size=annotation_outline_size)
+    component_value = _component_func(
+        binary=base64_pdf,
+        width=width,
+        height=height,
+        key=key,
+        default=0,
+        annotations=annotations,
+        pages_vertical_spacing=pages_vertical_spacing,
+        annotation_outline_size=annotation_outline_size,
+        rendering=rendering
+    )
     return component_value
 
 
@@ -70,4 +83,10 @@ if not _RELEASE:
     with open("resources/annotations.json", 'rb') as fo:
         annotations = json.loads(fo.read())
 
-    viewer = pdf_viewer(binary, height="700", width="800", annotations=annotations)
+    viewer = pdf_viewer(
+        binary,
+        height=700,
+        width=800,
+        annotations=annotations,
+        rendering="legacy_embed"
+    )

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -6,7 +6,7 @@ from typing import Union
 import streamlit.components.v1 as components
 import json
 
-_RELEASE = False
+_RELEASE = True
 
 if not _RELEASE:
     _component_func = components.declare_component(
@@ -87,6 +87,5 @@ if not _RELEASE:
         binary,
         height=700,
         width=800,
-        annotations=annotations,
-        rendering="legacy_embed"
+        annotations=annotations
     )

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -35,7 +35,6 @@ export default {
     const maxWidth = ref(0);
     const pageScales = ref([]);
     const pageHeights = ref([]);
-    const pageMargin = 2; // Set the margin between PDF pages to 2 pixels
 
 
     const pdfContainerStyle = computed(() => ({

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -1,11 +1,22 @@
 <template>
   <div id="pdfContainer" :style="pdfContainerStyle">
-    <div id="pdfViewer" :style="pdfViewerStyle">
-      <div id="pdfAnnotations" v-if="args.annotations">
-        <div v-for="(annotation, index) in args.annotations" :key="index" :style="getPageStyle">
-          <div :style="getAnnotationStyle(annotation)" :id="`annotation-${index}`"></div>
+    <div v-if="args.rendering==='unwrap'">
+      <div id="pdfViewer" :style="pdfViewerStyle">
+        <div id="pdfAnnotations" v-if="args.annotations">
+          <div v-for="(annotation, index) in args.annotations" :key="index" :style="getPageStyle">
+            <div :style="getAnnotationStyle(annotation)" :id="`annotation-${index}`"></div>
+          </div>
         </div>
       </div>
+    </div>
+    <div v-else-if="args.rendering==='legacy_embed'">
+      <embed :src="`data:application/pdf;base64,${args.binary}`" width="100%" height="700" type="application/pdf"/>
+    </div>
+    <div v-else-if="args.rendering==='legacy_iframe'">
+      <embed :src="`data:application/pdf;base64,${args.binary}`" width="100%" height="700" type="application/pdf"/>
+    </div>
+    <div v-else>
+      Error rendering option.
     </div>
   </div>
 </template>
@@ -137,7 +148,9 @@ export default {
 
     onMounted(() => {
       const binaryDataUrl = `data:application/pdf;base64,${props.args.binary}`;
-      loadPdfs(binaryDataUrl);
+      if (props.args.rendering === "unwrap") {
+        loadPdfs(binaryDataUrl);
+      }
       setFrameHeight();
     });
 


### PR DESCRIPTION
This PR adds the "legacy" viewer through <embed> or <iframe>. Annotations cannot be added for these methods.