### PR TITLE
PDF not showed when height is not set 

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,13 +15,13 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11', '3.12' ]
         node-version: [ 18, 20 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
       - name: build frontend

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: 'pip'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - name: build frontend

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -173,10 +173,13 @@ export default {
     onMounted(() => {
       const binaryDataUrl = `data:application/pdf;base64,${props.args.binary}`;
       if (props.args.rendering === "unwrap") {
-        loadPdfs(binaryDataUrl);
+        loadPdfs(binaryDataUrl)
+          .then(setFrameHeight)
+          .then(Streamlit.setComponentReady);
+      } else {
+        setFrameHeight();
+        Streamlit.setComponentReady();
       }
-      setFrameHeight();
-      Streamlit.setComponentReady();
     });
 
     onUpdated(() => {

--- a/tests/streamlit_apps/example_unwrap_no_args.py
+++ b/tests/streamlit_apps/example_unwrap_no_args.py
@@ -1,0 +1,10 @@
+import os
+
+import streamlit as st
+
+from streamlit_pdf_viewer import pdf_viewer
+from tests import ROOT_DIRECTORY
+
+st.subheader("Test PDF Viewer with no args")
+
+pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"))

--- a/tests/streamlit_apps/example_unwrap_width.py
+++ b/tests/streamlit_apps/example_unwrap_width.py
@@ -1,0 +1,10 @@
+import os
+
+import streamlit as st
+from tests import ROOT_DIRECTORY
+
+from streamlit_pdf_viewer import pdf_viewer
+
+st.subheader("Test PDF Viewer with arguments with specified width")
+
+pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"), width=400)

--- a/tests/test_unwrap_no_args.py
+++ b/tests/test_unwrap_no_args.py
@@ -1,0 +1,116 @@
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests import ROOT_DIRECTORY
+from tests.e2e_utils import StreamlitRunner
+
+BASIC_EXAMPLE_FILE = os.path.join(ROOT_DIRECTORY, "tests", "streamlit_apps", "example_unwrap_no_args.py")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def streamlit_app():
+    with StreamlitRunner(Path(BASIC_EXAMPLE_FILE)) as runner:
+        yield runner
+
+
+@pytest.fixture(autouse=True, scope="function")
+def go_to_app(page: Page, streamlit_app: StreamlitRunner):
+    page.goto(streamlit_app.server_url)
+    # Wait for app to load
+    page.get_by_role("img", name="Running...").is_hidden()
+
+
+def test_should_render_template_check_container_size(page: Page):
+    expect(page.get_by_text("Test PDF Viewer with no args")).to_be_visible()
+
+    iframe_component = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    expect(iframe_component).to_be_visible()
+
+    iframe_box = iframe_component.bounding_box()
+    assert iframe_box['width'] > 0
+    assert iframe_box['height'] > 0
+
+    iframe_frame = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]')
+    pdf_container = iframe_frame.locator('div[id="pdfContainer"]')
+    expect(pdf_container).to_be_visible()
+
+    b_box = pdf_container.bounding_box()
+    assert b_box['width'] == 700
+    assert b_box['height'] > 0
+
+    pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer).to_be_visible()
+
+    canvas_list = pdf_viewer.locator("canvas").all()
+    assert len(canvas_list) == 8
+    for canvas in canvas_list:
+        expect(canvas).to_be_visible()
+
+    annotations_locator = page.locator('div[id="pdfAnnotations"]').nth(0)
+    expect(annotations_locator).to_be_hidden()
+
+# def test_should_render_template(page: Page):
+#     frame_0 = page.frame_locator(
+#         'iframe[title="my_component\\.my_component"]'
+#     ).nth(0)
+#     frame_1 = page.frame_locator(
+#         'iframe[title="my_component\\.my_component"]'
+#     ).nth(1)
+#
+#     st_markdown_0 = page.get_by_role('paragraph').nth(0)
+#     st_markdown_1 = page.get_by_role('paragraph').nth(1)
+#
+#     expect(st_markdown_0).to_contain_text("You've clicked 0 times!")
+#
+#     frame_0.get_by_role("button", name="Click me!").click()
+#
+#     expect(st_markdown_0).to_contain_text("You've clicked 1 times!")
+#     expect(st_markdown_1).to_contain_text("You've clicked 0 times!")
+#
+#     frame_1.get_by_role("button", name="Click me!").click()
+#     frame_1.get_by_role("button", name="Click me!").click()
+#
+#     expect(st_markdown_0).to_contain_text("You've clicked 1 times!")
+#     expect(st_markdown_1).to_contain_text("You've clicked 2 times!")
+#
+#     page.get_by_label("Enter a name").click()
+#     page.get_by_label("Enter a name").fill("World")
+#     page.get_by_label("Enter a name").press("Enter")
+#
+#     expect(frame_1.get_by_text("Hello, World!")).to_be_visible()
+#
+#     frame_1.get_by_role("button", name="Click me!").click()
+#
+#     expect(st_markdown_0).to_contain_text("You've clicked 1 times!")
+#     expect(st_markdown_1).to_contain_text("You've clicked 3 times!")
+#
+#
+# def test_should_change_iframe_height(page: Page):
+#     frame = page.frame_locator('iframe[title="my_component\\.my_component"]').nth(1)
+#
+#     expect(frame.get_by_text("Hello, Streamlit!")).to_be_visible()
+#
+#     locator = page.locator('iframe[title="my_component\\.my_component"]').nth(1)
+#
+#     init_frame_height = locator.bounding_box()['height']
+#     assert init_frame_height != 0
+#
+#     page.get_by_label("Enter a name").click()
+#
+#     page.get_by_label("Enter a name").fill(35 * "Streamlit ")
+#     page.get_by_label("Enter a name").press("Enter")
+#
+#     expect(frame.get_by_text("Streamlit Streamlit Streamlit")).to_be_visible()
+#
+#     frame_height = locator.bounding_box()['height']
+#     assert frame_height > init_frame_height
+#
+#     page.set_viewport_size({"width": 150, "height": 150})
+#
+#     expect(frame.get_by_text("Streamlit Streamlit Streamlit")).not_to_be_in_viewport()
+#
+#     frame_height_after_viewport_change = locator.bounding_box()['height']
+#     assert frame_height_after_viewport_change > frame_height

--- a/tests/test_unwrap_width.py
+++ b/tests/test_unwrap_width.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests import ROOT_DIRECTORY
+from tests.e2e_utils import StreamlitRunner
+
+BASIC_EXAMPLE_FILE = os.path.join(ROOT_DIRECTORY, "tests", "streamlit_apps", "example_unwrap_width.py")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def streamlit_app():
+    with StreamlitRunner(Path(BASIC_EXAMPLE_FILE)) as runner:
+        yield runner
+
+
+@pytest.fixture(autouse=True, scope="function")
+def go_to_app(page: Page, streamlit_app: StreamlitRunner):
+    page.goto(streamlit_app.server_url)
+    # Wait for app to load
+    page.get_by_role("img", name="Running...").is_hidden()
+
+
+def test_should_render_template_check_container_size(page: Page):
+    expect(page.get_by_text("Test PDF Viewer with specified width")).to_be_visible()
+
+    iframe_component = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    expect(iframe_component).to_be_visible()
+
+    iframe_box = iframe_component.bounding_box()
+    assert iframe_box['width'] > 0
+    assert iframe_box['height'] > 0
+
+    iframe_frame = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    pdf_container = iframe_frame.locator('div[id="pdfContainer"]')
+    expect(pdf_container).to_be_visible()
+
+    b_box = pdf_container.bounding_box()
+    assert b_box['width'] == 400
+    assert b_box['height'] == 300
+
+    pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer).to_be_visible()
+
+    canvas_list = pdf_viewer.locator("canvas").all()
+    assert len(canvas_list) == 8
+    for canvas in canvas_list:
+        expect(canvas).to_be_visible()
+
+    annotations_locator = page.locator('div[id="pdfAnnotations"]').nth(0)
+    expect(annotations_locator).to_be_hidden()

--- a/tests/test_unwrap_width.py
+++ b/tests/test_unwrap_width.py
@@ -24,7 +24,7 @@ def go_to_app(page: Page, streamlit_app: StreamlitRunner):
 
 
 def test_should_render_template_check_container_size(page: Page):
-    expect(page.get_by_text("Test PDF Viewer with specified width")).to_be_visible()
+    expect(page.get_by_text("Test PDF Viewer with arguments with specified width")).to_be_visible()
 
     iframe_component = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
     expect(iframe_component).to_be_visible()
@@ -39,7 +39,7 @@ def test_should_render_template_check_container_size(page: Page):
 
     b_box = pdf_container.bounding_box()
     assert b_box['width'] == 400
-    assert b_box['height'] == 300
+    assert b_box['height'] >= 4216 # Firefox returns 4216.000091552734, while Chome 4216
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
     expect(pdf_viewer).to_be_visible()

--- a/tests/test_unwrap_width.py
+++ b/tests/test_unwrap_width.py
@@ -1,4 +1,5 @@
 import os
+from math import ceil, floor
 from pathlib import Path
 
 import pytest
@@ -38,8 +39,8 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 400
-    assert b_box['height'] >= 4216 # Firefox returns 4216.000091552734, while Chome 4216
+    assert floor(b_box['width']) == 400
+    assert floor(b_box['height']) == 4216 # Firefox returns 4216.000091552734, while Chome 4216
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
     expect(pdf_viewer).to_be_visible()


### PR DESCRIPTION
PDF is not showed in Chrome when the height is not set. 

The call to loading the PDF is async, but the setFrameHeight is called in sync, reading information that are supposed to be set in the loadPdf function. 