### PR TITLE
Deprecate legacy methods

### DIFF
--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -25,9 +25,9 @@ else:
     )
 
 
-def pdf_viewer(input: Union[str, Path, bytes], 
-               width: int = 700, 
-               height: int = None, 
+def pdf_viewer(input: Union[str, Path, bytes],
+               width: int = 700,
+               height: int = None,
                key=None,
                annotations: list = (),
                pages_vertical_spacing: int = 2,
@@ -70,9 +70,12 @@ def pdf_viewer(input: Union[str, Path, bytes],
             binary = fo.read()
     else:
         binary = input
-        
+
     if rendering == RENDERING_IFRAME or rendering == RENDERING_EMBED:
-        if height is None: 
+        console.warn(f"{RENDERING_IFRAME} and {RENDERING_EMBED} are deprecated. "
+                     f"They do not work consistently on all browswer "
+                     f"and will be removed in a future release.")
+        if height is None:
             height = "100%"
 
     base64_pdf = base64.b64encode(binary).decode('utf-8')

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -72,7 +72,7 @@ def pdf_viewer(input: Union[str, Path, bytes],
         binary = input
 
     if rendering == RENDERING_IFRAME or rendering == RENDERING_EMBED:
-        console.warn(f"{RENDERING_IFRAME} and {RENDERING_EMBED} are deprecated. "
+        print(f"{RENDERING_IFRAME} and {RENDERING_EMBED} are deprecated. "
                      f"They do not work consistently on all browswer "
                      f"and will be removed in a future release.")
         if height is None:

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -72,9 +72,8 @@ def pdf_viewer(input: Union[str, Path, bytes],
         binary = input
 
     if rendering == RENDERING_IFRAME or rendering == RENDERING_EMBED:
-        print(f"{RENDERING_IFRAME} and {RENDERING_EMBED} are deprecated. "
-                     f"They do not work consistently on all browswer "
-                     f"and will be removed in a future release.")
+        print(f"{RENDERING_IFRAME} and {RENDERING_EMBED} may not work consistently on all browsers "
+                     f"they might disapper in future releases.")
         if height is None:
             height = "100%"
 


### PR DESCRIPTION
This PR adds just a message when the other methods than `unwrap` are used. 
- ~~warning about deprecation~~

Reason:  https://github.com/lfoppiano/streamlit-pdf-viewer/issues/40