### PR TITLE
Fix scaling and display high PDF in high resolution

### DIFF
--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -26,7 +26,7 @@ else:
 
 
 def pdf_viewer(input: Union[str, Path, bytes], 
-               width: int = 700, 
+               width: int = None,
                height: int = None, 
                key=None,
                annotations: list = (),
@@ -58,7 +58,7 @@ def pdf_viewer(input: Union[str, Path, bytes],
     """
 
     # Validate width and height parameters
-    if not isinstance(width, int):
+    if width is not None and not isinstance(width, int):
         raise TypeError("Width must be an integer")
     if height is not None and not isinstance(height, int):
         raise TypeError("Height must be an integer or None")
@@ -100,7 +100,7 @@ if not _RELEASE:
 
     viewer = pdf_viewer(
         binary,
-        height=700,
+        # height=700,
         width=800,
         annotations=annotations
     )

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -62,7 +62,7 @@ export default {
     });
 
     const pdfContainerStyle = computed(() => ({
-      width: `${props.args.width}px`,
+      width: props.args.width ? `${props.args.width}px` : `${maxWidth.value}px`,
       height: props.args.height ? `${props.args.height}px` : 'auto',
       overflow: 'auto',
     }));
@@ -150,21 +150,7 @@ export default {
         }
       }
 
-      if (props.args.width === null || props.args.width === undefined) {
-        maxWidth.value = window.innerWidth
-      } else if (Number.isInteger(props.args.width)) {
-        maxWidth.value = props.args.width
-
-        // If the desired width is larger than the available inner width,
-        // we should not exceed it. To be revised
-        if (window.innerWidth < maxWidth.value) {
-          maxWidth.value = window.innerWidth
-        }
-      }
-
-      // const PRINT_UNITS = 300 / 72.0
-
-      console.log("Device pixel ratio" + window.devicePixelRatio)
+      // console.log("Device pixel ratio" + window.devicePixelRatio)
       for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
         const page = await pdf.getPage(pageNumber)
         const rotation = page.rotate
@@ -216,8 +202,23 @@ export default {
       Streamlit.setFrameHeight(props.args.height || totalHeight.value);
     };
 
+    const setFrameWidth = () => {
+      if (props.args.width === null || props.args.width === undefined) {
+        maxWidth.value = window.innerWidth
+      } else if (Number.isInteger(props.args.width)) {
+        maxWidth.value = props.args.width
+
+        // If the desired width is larger than the available inner width,
+        // we should not exceed it. To be revised
+        if (window.innerWidth < maxWidth.value) {
+          maxWidth.value = window.innerWidth
+        }
+      }
+    }
+
     onMounted(() => {
       const binaryDataUrl = `data:application/pdf;base64,${props.args.binary}`;
+      setFrameWidth();
       if (props.args.rendering === "unwrap") {
         loadPdfs(binaryDataUrl)
           .then(setFrameHeight)

--- a/tests/streamlit_apps/example_invalid_params.py
+++ b/tests/streamlit_apps/example_invalid_params.py
@@ -1,0 +1,12 @@
+import os
+
+import streamlit as st
+
+from streamlit_pdf_viewer import pdf_viewer
+from tests import ROOT_DIRECTORY
+
+st.subheader("Test PDF Viewer using legacy embed with specified height")
+
+pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"), rendering='unwrap', height='500')
+pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"), rendering='unwrap', width='500')
+pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"), rendering='unwrap', width='500', height='500')

--- a/tests/test_embed_height.py
+++ b/tests/test_embed_height.py
@@ -48,8 +48,10 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 700
-    assert b_box['height'] > 0
+    assert round(b_box['height']) == 500
+    # Since we do not specify the width, we occupy all the available space, which should correspond to the
+    # parent element's width of the pdfContainer.
+    assert b_box['width'] == iframe_box['width']
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
     expect(pdf_viewer).not_to_be_visible()

--- a/tests/test_embed_no_args.py
+++ b/tests/test_embed_no_args.py
@@ -48,7 +48,9 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 700
+    # Since we do not specify the width, we occupy all the available space, which should correspond to the
+    # parent element's width of the pdfContainer.
+    assert b_box['width'] == iframe_box['width']
     assert b_box['height'] > 0
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')

--- a/tests/test_iframe_height.py
+++ b/tests/test_iframe_height.py
@@ -48,7 +48,9 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 700
+    # Since we do not specify the width, we occupy all the available space, which should correspond to the
+    # parent element's width of the pdfContainer.
+    assert b_box['width'] == iframe_box['width']
     assert b_box['height'] > 0
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')

--- a/tests/test_iframe_no_args.py
+++ b/tests/test_iframe_no_args.py
@@ -48,7 +48,9 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 700
+    # Since we do not specify the width, we occupy all the available space, which should correspond to the
+    # parent element's width of the pdfContainer.
+    assert b_box['width'] == iframe_box['width']
     assert b_box['height'] > 0
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')

--- a/tests/test_invalid_params.py
+++ b/tests/test_invalid_params.py
@@ -1,0 +1,47 @@
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests import ROOT_DIRECTORY
+from tests.e2e_utils import StreamlitRunner
+
+BASIC_EXAMPLE_FILE = os.path.join(ROOT_DIRECTORY, "tests", "streamlit_apps", "example_invalid_params.py")
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args):
+    return {
+        **browser_type_launch_args,
+        "firefox_user_prefs": {
+            "pdfjs.disabled": False,
+        }
+    }
+
+
+@pytest.fixture(autouse=True, scope="module")
+def streamlit_app():
+    with StreamlitRunner(Path(BASIC_EXAMPLE_FILE)) as runner:
+        yield runner
+
+
+@pytest.fixture(autouse=True, scope="function")
+def go_to_app(page: Page, streamlit_app: StreamlitRunner):
+    page.goto(streamlit_app.server_url)
+    # Wait for app to load
+    page.get_by_role("img", name="Running...").is_hidden()
+
+
+def test_should_fail_rendering(page: Page):
+    expect(page.get_by_text("Test PDF Viewer using legacy embed with specified height")).to_be_visible()
+
+    iframe_component = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    expect(iframe_component).not_to_be_visible()
+
+    iframe_frame = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]')
+    pdf_container = iframe_frame.locator('div[id="pdfContainer"]')
+    expect(pdf_container).not_to_be_visible()
+
+    pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer).not_to_be_visible()

--- a/tests/test_unwrap_height.py
+++ b/tests/test_unwrap_height.py
@@ -38,7 +38,9 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 700
+    # Since we do not specify the width, we occupy all the available space, which should correspond to the
+    # parent element's width of the pdfContainer.
+    assert b_box['width'] == iframe_box['width']
     assert b_box['height'] == 300
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')

--- a/tests/test_unwrap_no_args.py
+++ b/tests/test_unwrap_no_args.py
@@ -38,7 +38,9 @@ def test_should_render_template_check_container_size(page: Page):
     expect(pdf_container).to_be_visible()
 
     b_box = pdf_container.bounding_box()
-    assert b_box['width'] == 700
+    # Since we do not specify the width, we occupy all the available space, which should correspond to the
+    # parent element's width of the pdfContainer.
+    assert b_box['width'] == iframe_box['width']
     assert b_box['height'] > 0
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')

--- a/tests/test_unwrap_width.py
+++ b/tests/test_unwrap_width.py
@@ -40,7 +40,7 @@ def test_should_render_template_check_container_size(page: Page):
 
     b_box = pdf_container.bounding_box()
     assert floor(b_box['width']) == 400
-    assert floor(b_box['height']) == 4221 # Firefox returns 4216.000091552734, while Chome 4216
+    assert floor(b_box['height']) == 4221
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
     expect(pdf_viewer).to_be_visible()

--- a/tests/test_unwrap_width.py
+++ b/tests/test_unwrap_width.py
@@ -40,7 +40,7 @@ def test_should_render_template_check_container_size(page: Page):
 
     b_box = pdf_container.bounding_box()
     assert floor(b_box['width']) == 400
-    assert floor(b_box['height']) == 4216 # Firefox returns 4216.000091552734, while Chome 4216
+    assert floor(b_box['height']) == 4221 # Firefox returns 4216.000091552734, while Chome 4216
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')
     expect(pdf_viewer).to_be_visible()


### PR DESCRIPTION
This PR addresses #48, providing a better resolution. 

In addition: 
- the desired width should never be larger than the available screen, so it does not show half PDF in the screen 
- the width scales also when the window is smaller than the desired with 

So far results looks better: 

<img width="1346" alt="image" src="https://github.com/lfoppiano/streamlit-pdf-viewer/assets/15426/60e6ea19-c1eb-4e08-9e59-35ff60debbee">

Some references: https://gist.github.com/callumlocke/cc258a193839691f60dd
