### PR TITLE
Fix canvas and rendering problems 

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -3,3 +3,18 @@ current_version = "0.0.14"
 commit = "true"
 tag = "true"
 tag_name = "v{new_version}"
+
+parse = """(?x)
+    (?P<major>0|[1-9]\\d*)\\.
+    (?P<minor>0|[1-9]\\d*)\\.
+    (?P<patch>0|[1-9]\\d*)
+    (?:
+        -                             # dash separator for pre-release section
+        (?P<pre_l>[a-zA-Z-]+)         # pre-release label
+        (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
+    )?                                # pre-release section is optional
+"""
+
+[tool.bumpversion.parts.pre_l]
+values = ["dev", "rc", "final"]
+optional_value = "final"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.14"
+current_version = "0.0.15"
 commit = "true"
 tag = "true"
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -15,6 +15,11 @@ parse = """(?x)
     )?                                # pre-release section is optional
 """
 
+serialize = [
+    "{major}.{minor}.{patch}-{pre_l}{pre_n}",
+    "{major}.{minor}.{patch}",
+]
+
 [tool.bumpversion.parts.pre_l]
 values = ["dev", "rc", "final"]
 optional_value = "final"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.15"
+current_version = "0.0.16-dev0"
 commit = "true"
 tag = "true"
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.16-dev0"
+current_version = "0.0.16-dev1"
 commit = "true"
 tag = "true"
 tag_name = "v{new_version}"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 streamlit_pdf_viewer/frontend/package-lock.json
 streamlit_pdf_viewer.egg-info
 streamlit_pdf_viewer/__pycache__/
+tests/__pycache__

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -97,15 +97,33 @@ def pdf_viewer(input: Union[str, Path, bytes],
 
 
 if not _RELEASE:
+    import streamlit as st
+
     with open("resources/test.pdf", 'rb') as fo:
         binary = fo.read()
+
+    with open("resources/test.pdf", 'rb') as fo:
+        binary2 = fo.read()
 
     with open("resources/annotations.sample.json", 'rb') as fo:
         annotations = json.loads(fo.read())
 
-    viewer = pdf_viewer(
-        binary,
-        width=800,
-        annotations=annotations,
-        render_text=True
-    )
+    tab1, tab2 = st.tabs(["tab1", "tab2"])
+
+    with tab1:
+        st.markdown("BAO")
+        viewer = pdf_viewer(
+            binary,
+            height=300,
+            annotations=annotations,
+            render_text=False,
+            key="bao"
+        )
+    with tab2:
+        st.markdown("Miao")
+        viewer2 = pdf_viewer(
+            binary2,
+            height=300,
+            render_text=False,
+            key="miao"
+        )

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -111,20 +111,20 @@ if not _RELEASE:
     tab1, tab2 = st.tabs(["tab1", "tab2"])
 
     with tab1:
-        st.markdown("BAO")
-        viewer = pdf_viewer(
-            binary,
-            width=400,
-            height=400,
-            annotations=annotations,
-            render_text=False,
-            key="bao"
-        )
+        st.markdown("tab 1")
+        with st.container(height=300):
+            viewer = pdf_viewer(
+                binary,
+                annotations=annotations,
+                render_text=True,
+                key="bao"
+            )
     with tab2:
-        st.markdown("Miao")
+        st.markdown("tab 2")
         viewer2 = pdf_viewer(
             binary2,
-            height=400,
-            render_text=False,
+            height=500,
+            annotations=annotations,
+            render_text=True,
             key="miao"
         )

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -114,7 +114,8 @@ if not _RELEASE:
         st.markdown("BAO")
         viewer = pdf_viewer(
             binary,
-            height=300,
+            width=400,
+            height=400,
             annotations=annotations,
             render_text=False,
             key="bao"
@@ -123,7 +124,7 @@ if not _RELEASE:
         st.markdown("Miao")
         viewer2 = pdf_viewer(
             binary2,
-            height=300,
+            height=400,
             render_text=False,
             key="miao"
         )

--- a/streamlit_pdf_viewer/frontend/package.json
+++ b/streamlit_pdf_viewer/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
-    "pdfjs-dist": "^4.2.67",
+    "pdfjs-dist": "^4.5.136",
     "streamlit-component-lib": "^2.0.0",
     "vue": "^3.0.0-0"
   },

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -274,8 +274,10 @@ export default {
 
         // If the desired width is larger than the available inner width,
         // we should not exceed it. To be revised
-        if (0 < window.innerWidth < maxWidth.value) {
-          maxWidth.value = window.innerWidth
+        if (window.innerWidth > 0) {
+          if (window.innerWidth < maxWidth.value) {
+            maxWidth.value = window.innerWidth
+          }
         }
       }
     }

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -135,12 +135,14 @@ export default {
         // textLayerDiv.style.position = "absolute";
         // textLayerDiv.style.height = `${viewport.height}px`;
         // textLayerDiv.style.width = `${viewport.width}px`;
-        pdfjsLib.renderTextLayer({
+        const textLayer = new pdfjsLib.TextLayer({
           textContentSource: textContent,
           container: textLayerDiv,
           viewport: viewport,
           textDivs: []
         })
+        await textLayer.render()
+        
         const pageDiv = document.createElement('div');
         pageDiv.className = 'page';
 

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -186,12 +186,35 @@ export default {
           rotation: rotation,
         })
 
+        // console.log(`unscaledViewport ${pageNumber}`)
+        // console.log(unscaledViewport)
+
+        // console.log("Max width")
+        // console.log(maxWidth.value)
+
+        // console.log("Height")
+        // console.log(props.args.height)
+
+        if (props.args.height > 0) {
+          let widthScale =  unscaledViewport.width / unscaledViewport.height
+          const possibleScaledWidth = widthScale * props.args.height
+          if (maxWidth.value === 0) {
+            maxWidth.value = possibleScaledWidth
+          } else if (possibleScaledWidth < maxWidth.value) {
+            maxWidth.value = possibleScaledWidth
+          }
+        }
+
         const scale = maxWidth.value / unscaledViewport.width
 
         pageScales.value.push(scale)
         pageHeights.value.push(unscaledViewport.height)
         if (pagesToRender.includes(pageNumber)) {
           const canvas = createCanvasForPage(page, scale, rotation, pageNumber)
+
+          // console.log(`canvas`)
+          // console.log(canvas)
+
           // pdfViewer?.append(canvas)
           pdfViewer.style.setProperty('--scale-factor', scale);
 
@@ -200,6 +223,9 @@ export default {
             rotation: page.rotate,
             intent: "print",
           });
+
+          // console.log(`Scaled viewport`)
+          // console.log(viewport)
 
           const ratio = window.devicePixelRatio || 1
           totalHeight.value += canvas.height / ratio
@@ -248,7 +274,7 @@ export default {
 
         // If the desired width is larger than the available inner width,
         // we should not exceed it. To be revised
-        if (window.innerWidth < maxWidth.value) {
+        if (0 < window.innerWidth < maxWidth.value) {
           maxWidth.value = window.innerWidth
         }
       }

--- a/tests/streamlit_apps/example_tab.py
+++ b/tests/streamlit_apps/example_tab.py
@@ -1,0 +1,16 @@
+import os
+
+import streamlit as st
+
+from streamlit_pdf_viewer import pdf_viewer
+from tests import ROOT_DIRECTORY
+
+st.subheader("Test PDF Viewer with the PDF in a tab")
+
+tab1, tab2 = st.tabs(["tab1", "tab2"])
+
+with tab1:
+    pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"))
+
+with tab2:
+    pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"), width=300)

--- a/tests/streamlit_apps/example_tab_2.py
+++ b/tests/streamlit_apps/example_tab_2.py
@@ -1,0 +1,16 @@
+import os
+
+import streamlit as st
+
+from streamlit_pdf_viewer import pdf_viewer
+from tests import ROOT_DIRECTORY
+
+st.subheader("Test PDF Viewer with the PDF in a tab 2")
+
+tab1, tab2 = st.tabs(["tab1", "tab2"])
+
+with tab1:
+    pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"))
+
+with tab2:
+    pdf_viewer(os.path.join(ROOT_DIRECTORY, "resources/test.pdf"), height=300)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,0 +1,90 @@
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests import ROOT_DIRECTORY
+from tests.e2e_utils import StreamlitRunner
+
+BASIC_EXAMPLE_FILE = os.path.join(ROOT_DIRECTORY, "tests", "streamlit_apps", "example_tab.py")
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args):
+    return {
+        **browser_type_launch_args,
+        "firefox_user_prefs": {
+            "pdfjs.disabled": False,
+        }
+    }
+
+
+@pytest.fixture(autouse=True, scope="module")
+def streamlit_app():
+    with StreamlitRunner(Path(BASIC_EXAMPLE_FILE)) as runner:
+        yield runner
+
+
+@pytest.fixture(autouse=True, scope="function")
+def go_to_app(page: Page, streamlit_app: StreamlitRunner):
+    page.goto(streamlit_app.server_url)
+    # Wait for app to load
+    page.get_by_role("img", name="Running...").is_hidden()
+
+
+def test_should_render_template_check_container_size(page: Page):
+    expect(page.get_by_text("Test PDF Viewer with the PDF in a tab")).to_be_visible()
+
+    iframe_component = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    expect(iframe_component).to_be_visible()
+
+    iframe_box = iframe_component.bounding_box()
+    assert iframe_box['width'] > 0
+    assert iframe_box['height'] > 0
+
+    # Tab 1
+    iframe_frame_0 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    pdf_container_0 = iframe_frame_0.locator('div[id="pdfContainer"]')
+    expect(pdf_container_0).to_be_visible()
+
+    b_box_0 = pdf_container_0.bounding_box()
+    assert round(b_box_0['height']) > iframe_box['height']
+    assert b_box_0['width'] == iframe_box['width']
+
+    pdf_viewer_0 = iframe_frame_0.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer_0).to_be_visible()
+
+    annotations_locator = page.locator('div[id="pdfAnnotations"]').nth(0)
+    expect(annotations_locator).to_be_hidden()
+
+    # Tab 2
+    iframe_frame_1 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(1)
+    pdf_container_1 = iframe_frame_1.locator('div[id="pdfContainer"]')
+    expect(pdf_container_1).not_to_be_visible()
+
+    pdf_viewer_1 = iframe_frame_1.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer_1).not_to_be_visible()
+
+    annotations_locator = page.locator('div[id="pdfAnnotations"]').nth(1)
+    expect(annotations_locator).to_be_hidden()
+
+    tab0 = page.get_by_text('tab1')
+    expect(tab0).to_be_visible()
+
+    tab1 = page.get_by_text('tab2')
+    expect(tab1).to_be_visible()
+
+    # click on the second tab and verify that the PDF is visible
+    tab1.click()
+
+    iframe_frame_1 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(1)
+    pdf_container_1 = iframe_frame_1.locator('div[id="pdfContainer"]')
+    expect(pdf_container_1).to_be_visible()
+
+    b_box_1 = pdf_container_1.bounding_box()
+    assert round(b_box_1['height']) < iframe_box['height'] and round(b_box_1['height']) > 0
+    assert b_box_1['width'] == 300
+
+    pdf_viewer_1 = iframe_frame_1.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer_1).to_be_visible()

--- a/tests/test_tabs_2.py
+++ b/tests/test_tabs_2.py
@@ -1,0 +1,92 @@
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests import ROOT_DIRECTORY
+from tests.e2e_utils import StreamlitRunner
+
+BASIC_EXAMPLE_FILE = os.path.join(ROOT_DIRECTORY, "tests", "streamlit_apps", "example_tab_2.py")
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args):
+    return {
+        **browser_type_launch_args,
+        "firefox_user_prefs": {
+            "pdfjs.disabled": False,
+        }
+    }
+
+
+@pytest.fixture(autouse=True, scope="module")
+def streamlit_app():
+    with StreamlitRunner(Path(BASIC_EXAMPLE_FILE)) as runner:
+        yield runner
+
+
+@pytest.fixture(autouse=True, scope="function")
+def go_to_app(page: Page, streamlit_app: StreamlitRunner):
+    page.goto(streamlit_app.server_url)
+    # Wait for app to load
+    page.get_by_role("img", name="Running...").is_hidden()
+
+
+def test_should_render_template_check_container_size(page: Page):
+    expect(page.get_by_text("Test PDF Viewer with the PDF in a tab")).to_be_visible()
+
+    iframe_component = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    expect(iframe_component).to_be_visible()
+
+    iframe_box = iframe_component.bounding_box()
+    assert iframe_box['width'] > 0
+    assert iframe_box['height'] > 0
+
+    # Tab 1
+    iframe_frame_0 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    pdf_container_0 = iframe_frame_0.locator('div[id="pdfContainer"]')
+    expect(pdf_container_0).to_be_visible()
+
+    b_box_0 = pdf_container_0.bounding_box()
+    assert round(b_box_0['height']) > iframe_box['height']
+    assert b_box_0['width'] == iframe_box['width']
+
+    pdf_viewer_0 = iframe_frame_0.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer_0).to_be_visible()
+
+    annotations_locator = page.locator('div[id="pdfAnnotations"]').nth(0)
+    expect(annotations_locator).to_be_hidden()
+
+    # Tab 2
+    iframe_frame_1 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(1)
+    pdf_container_1 = iframe_frame_1.locator('div[id="pdfContainer"]')
+    expect(pdf_container_1).not_to_be_visible()
+
+    pdf_viewer_1 = iframe_frame_1.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer_1).not_to_be_visible()
+
+    annotations_locator = page.locator('div[id="pdfAnnotations"]').nth(1)
+    expect(annotations_locator).to_be_hidden()
+
+    tab0 = page.get_by_text('tab1')
+    expect(tab0).to_be_visible()
+
+    tab1 = page.get_by_text('tab2')
+    expect(tab1).to_be_visible()
+
+    # click on the second tab and verify that the PDF is visible
+    tab1.click()
+
+    iframe_frame_1 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(1)
+    pdf_container_1 = iframe_frame_1.locator('div[id="pdfContainer"]')
+    expect(pdf_container_1).to_be_visible()
+
+    b_box_1 = pdf_container_1.bounding_box()
+    assert b_box_1['height'] == 300
+    # The second part of the If tests that the width < height, which indicate that we have resized
+    # the PDF to keep the proportions
+    assert round(b_box_1['width']) < iframe_box['width'] and round(b_box_1['width']) < round(b_box_1['height'])
+
+    pdf_viewer_1 = iframe_frame_1.locator('div[id="pdfViewer"]')
+    expect(pdf_viewer_1).to_be_visible()

--- a/tests/test_unwrap_height.py
+++ b/tests/test_unwrap_height.py
@@ -40,7 +40,8 @@ def test_should_render_template_check_container_size(page: Page):
     b_box = pdf_container.bounding_box()
     # Since we do not specify the width, we occupy all the available space, which should correspond to the
     # parent element's width of the pdfContainer.
-    assert b_box['width'] == iframe_box['width']
+    # LF: This was changed with #58, where the proportions are maintained, or at least we try to
+    assert b_box['width'] < iframe_box['width']
     assert b_box['height'] == 300
 
     pdf_viewer = iframe_frame.locator('div[id="pdfViewer"]')


### PR DESCRIPTION
This PR should fix #54, #53 and #56 

The cause of these issues that happens with tabs and expanders comes from our attempt to get the dimension of the space around the PDF, when the width / height are not specified. In addition to a few bugs 😄 

In the case of tabs or expanders, if the PDF is not visible, the width and height of the outer item are 0. From now on, the user has to specify the width or height in such cases. 

Finally, with version <= 0.0.14 when width was not specified, the component tried to use all the available space. Now, if the width is not specified, but the height it is, the PDF will be shown in proportion. 