### PR TITLE
Improve viewer resolution

### DIFF
--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -35,7 +35,7 @@ def pdf_viewer(input: Union[str, Path, bytes],
                rendering: str = RENDERING_UNWRAP,
                pages_to_render: List[int] = (),
                render_text: bool = False,
-               ratio_boost: int = 1
+               resolution_boost: int = 1
                ):
     """
     pdf_viewer function to display a PDF file in a Streamlit app.
@@ -53,6 +53,7 @@ def pdf_viewer(input: Union[str, Path, bytes],
     These methods enable the default pdf viewer of Firefox/Chrome/Edge that contains additional features we are still
     working to implement for the "unwrap" method.
     :param render_text: Whether to enable selection of text in the PDF viewer. Defaults to False.
+    :param resolution_boost: Boost the resolution by a factor from 2 to 10. Defaults to 1.
 
     The function reads the PDF file (from a file path, URL, or binary data), encodes it in base64,
     and uses a Streamlit component to render it in the app. It supports optional annotations and adjustable margins.
@@ -68,9 +69,9 @@ def pdf_viewer(input: Union[str, Path, bytes],
     if not all(isinstance(page, int) for page in pages_to_render):
         raise TypeError("pages_to_render must be a list of integers")
 
-    if ratio_boost < 1:
+    if resolution_boost < 1:
         raise ValueError("ratio_boost must be greater than 1")
-    elif ratio_boost > 10:
+    elif resolution_boost > 10:
         raise ValueError("ratio_boost must be lower than 10")
 
     if type(input) is not bytes:
@@ -98,7 +99,7 @@ def pdf_viewer(input: Union[str, Path, bytes],
         rendering=rendering,
         pages_to_render=pages_to_render,
         render_text=render_text,
-        ratio_boost=ratio_boost
+        ratio_boost=resolution_boost
     )
     return component_value
 
@@ -133,5 +134,6 @@ if not _RELEASE:
             height=500,
             annotations=annotations,
             render_text=True,
-            key="miao"
+            key="miao",
+            resolution_boost=4
         )

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -99,7 +99,7 @@ def pdf_viewer(input: Union[str, Path, bytes],
         rendering=rendering,
         pages_to_render=pages_to_render,
         render_text=render_text,
-        ratio_boost=resolution_boost
+        resolution_boost=resolution_boost
     )
     return component_value
 

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -34,7 +34,8 @@ def pdf_viewer(input: Union[str, Path, bytes],
                annotation_outline_size: int = 1,
                rendering: str = RENDERING_UNWRAP,
                pages_to_render: List[int] = (),
-               render_text: bool = False
+               render_text: bool = False,
+               ratio_boost: int = 1
                ):
     """
     pdf_viewer function to display a PDF file in a Streamlit app.
@@ -67,6 +68,11 @@ def pdf_viewer(input: Union[str, Path, bytes],
     if not all(isinstance(page, int) for page in pages_to_render):
         raise TypeError("pages_to_render must be a list of integers")
 
+    if ratio_boost < 1:
+        raise ValueError("ratio_boost must be greater than 1")
+    elif ratio_boost > 10:
+        raise ValueError("ratio_boost must be lower than 10")
+
     if type(input) is not bytes:
         with open(input, 'rb') as fo:
             binary = fo.read()
@@ -91,7 +97,8 @@ def pdf_viewer(input: Union[str, Path, bytes],
         annotation_outline_size=annotation_outline_size,
         rendering=rendering,
         pages_to_render=pages_to_render,
-        render_text=render_text
+        render_text=render_text,
+        ratio_boost=ratio_boost
     )
     return component_value
 

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -107,6 +107,17 @@ def pdf_viewer(input: Union[str, Path, bytes],
 if not _RELEASE:
     import streamlit as st
 
+    # from glob import glob
+
+    # paths = glob("/Users/lfoppiano/kDrive/library/articles/materials informatics/polymers/*.pdf")
+    # path = "/Users/lfoppiano/development/projects/alirahelth/data/articles/Basso Dias RAD 2022.pdf"
+    # values = list(range(1, 10))
+    # for id, tab in enumerate(st.tabs([f"tab {val}" for val in values])):
+    #     with tab:
+    #         with st.container(height=600):
+    #             pdf_viewer(path, width=800, render_text=True, resolution_boost=values[id])
+    #
+
     with open("resources/test.pdf", 'rb') as fo:
         binary = fo.read()
 

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -181,7 +181,7 @@ export default {
       }
 
       let resolutionBoost = 1
-      if (props.args.ratio_boost) {
+      if (props.args.resolution_boost) {
         resolutionBoost = props.args.resolution_boost
       }
 

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -102,10 +102,11 @@ export default {
       }
     };
 
-    const createCanvasForPage = (page, scale, rotation, pageNumber) => {
+    const createCanvasForPage = (page, scale, rotation, pageNumber, ratioBoost=1) => {
       const viewport = page.getViewport({scale, rotation});
 
-      const ratio = window.devicePixelRatio || 1
+      const ratio = (window.devicePixelRatio || 1) * ratioBoost
+      // console.log(ratio)
 
       const canvas = document.createElement("canvas");
       canvas.id = `canvas_page_${pageNumber}`;
@@ -179,6 +180,11 @@ export default {
         }
       }
 
+      let ratioBoost = 1
+      if (props.args.ratio_boost) {
+        ratioBoost = props.args.ratio_boost
+      }
+
       for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
         const page = await pdf.getPage(pageNumber)
         const rotation = page.rotate
@@ -212,7 +218,7 @@ export default {
         pageScales.value.push(scale)
         pageHeights.value.push(unscaledViewport.height)
         if (pagesToRender.includes(pageNumber)) {
-          const canvas = createCanvasForPage(page, scale, rotation, pageNumber)
+          const canvas = createCanvasForPage(page, scale, rotation, pageNumber, ratioBoost)
 
           // console.log(`canvas`)
           // console.log(canvas)

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -180,9 +180,9 @@ export default {
         }
       }
 
-      let ratioBoost = 1
+      let ResolutionBoost = 1
       if (props.args.ratio_boost) {
-        ratioBoost = props.args.ratio_boost
+        ResolutionBoost = props.args.resolution_boost
       }
 
       for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
@@ -218,7 +218,7 @@ export default {
         pageScales.value.push(scale)
         pageHeights.value.push(unscaledViewport.height)
         if (pagesToRender.includes(pageNumber)) {
-          const canvas = createCanvasForPage(page, scale, rotation, pageNumber, ratioBoost)
+          const canvas = createCanvasForPage(page, scale, rotation, pageNumber, ResolutionBoost)
 
           // console.log(`canvas`)
           // console.log(canvas)

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -102,10 +102,10 @@ export default {
       }
     };
 
-    const createCanvasForPage = (page, scale, rotation, pageNumber, ratioBoost=1) => {
+    const createCanvasForPage = (page, scale, rotation, pageNumber, resolutionRatioBoost=1) => {
       const viewport = page.getViewport({scale, rotation});
 
-      const ratio = (window.devicePixelRatio || 1) * ratioBoost
+      const ratio = (window.devicePixelRatio || 1) * resolutionRatioBoost
       // console.log(ratio)
 
       const canvas = document.createElement("canvas");
@@ -180,9 +180,9 @@ export default {
         }
       }
 
-      let ResolutionBoost = 1
+      let resolutionBoost = 1
       if (props.args.ratio_boost) {
-        ResolutionBoost = props.args.resolution_boost
+        resolutionBoost = props.args.resolution_boost
       }
 
       for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
@@ -218,7 +218,7 @@ export default {
         pageScales.value.push(scale)
         pageHeights.value.push(unscaledViewport.height)
         if (pagesToRender.includes(pageNumber)) {
-          const canvas = createCanvasForPage(page, scale, rotation, pageNumber, ResolutionBoost)
+          const canvas = createCanvasForPage(page, scale, rotation, pageNumber, resolutionBoost)
 
           // console.log(`canvas`)
           // console.log(canvas)

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -235,7 +235,7 @@ export default {
           // console.log(`Scaled viewport`)
           // console.log(viewport)
 
-          const ratio = window.devicePixelRatio || 1
+          const ratio = (window.devicePixelRatio || 1) * resolutionBoost
           totalHeight.value += canvas.height / ratio
           await renderPage(page, canvas, viewport)
         }

--- a/tests/streamlit_apps/example_resolution_boost.py
+++ b/tests/streamlit_apps/example_resolution_boost.py
@@ -1,0 +1,27 @@
+import os
+
+import streamlit as st
+from streamlit import markdown
+
+from streamlit_pdf_viewer import pdf_viewer
+from tests import ROOT_DIRECTORY
+
+st.subheader("Test PDF Viewer with different resolution boosts")
+
+pdf_path = os.path.join(ROOT_DIRECTORY, "resources/test.pdf")
+
+tabs = st.tabs(["tab 1", "tab 2"])
+
+resolution_boost_values = list(range(1, 10, 3))
+labels = [f"tab {resolution_boost_value}" for resolution_boost_value in resolution_boost_values]
+with tabs[0]:
+    for id, column in enumerate(st.columns(len(labels))):
+        with column:
+            markdown(f"Resolution boost: {resolution_boost_values[id]}")
+            pdf_viewer(pdf_path, width=200, render_text=False, resolution_boost=resolution_boost_values[id])
+
+with tabs[1]:
+    for id, column in enumerate(st.columns(len(labels))):
+        with column:
+            markdown(f"Resolution boost: {resolution_boost_values[id]}")
+            pdf_viewer(pdf_path, width=200, render_text=True, resolution_boost=resolution_boost_values[id])

--- a/tests/test_resolution_boost.py
+++ b/tests/test_resolution_boost.py
@@ -36,7 +36,8 @@ def go_to_app(page: Page, streamlit_app: StreamlitRunner):
 def test_resolution_boost(page: Page):
     expect(page.get_by_text("Test PDF Viewer with different resolution boosts")).to_be_visible()
     page.wait_for_selector('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]')
-    page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(6).wait_for("visible")
+    page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(2).wait_for(state="visible")
+    page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(6).wait_for(state="hidden")
     iframe_components = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').all()
     assert len(iframe_components) == 6
 

--- a/tests/test_resolution_boost.py
+++ b/tests/test_resolution_boost.py
@@ -33,10 +33,10 @@ def go_to_app(page: Page, streamlit_app: StreamlitRunner):
     page.get_by_role("img", name="Running...").is_hidden()
 
 
-def test_should_render_template_check_container_size(page: Page):
+def test_resolution_boost(page: Page):
     expect(page.get_by_text("Test PDF Viewer with different resolution boosts")).to_be_visible()
     page.wait_for_selector('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]')
-    page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(6)
+    page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(6).wait_for("visible")
     iframe_components = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').all()
     assert len(iframe_components) == 6
 

--- a/tests/test_resolution_boost.py
+++ b/tests/test_resolution_boost.py
@@ -1,0 +1,106 @@
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests import ROOT_DIRECTORY
+from tests.e2e_utils import StreamlitRunner
+
+BASIC_EXAMPLE_FILE = os.path.join(ROOT_DIRECTORY, "tests", "streamlit_apps", "example_resolution_boost.py")
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args):
+    return {
+        **browser_type_launch_args,
+        "firefox_user_prefs": {
+            "pdfjs.disabled": False,
+        }
+    }
+
+
+@pytest.fixture(autouse=True, scope="module")
+def streamlit_app():
+    with StreamlitRunner(Path(BASIC_EXAMPLE_FILE)) as runner:
+        yield runner
+
+
+@pytest.fixture(autouse=True, scope="function")
+def go_to_app(page: Page, streamlit_app: StreamlitRunner):
+    page.goto(streamlit_app.server_url)
+    # Wait for app to load
+    page.get_by_role("img", name="Running...").is_hidden()
+
+
+def test_should_render_template_check_container_size(page: Page):
+    expect(page.get_by_text("Test PDF Viewer with different resolution boosts")).to_be_visible()
+    page.wait_for_selector('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]')
+    page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(6)
+    iframe_components = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').all()
+    assert len(iframe_components) == 6
+
+    expect(iframe_components[0]).to_be_visible()
+    expect(iframe_components[1]).to_be_visible()
+    expect(iframe_components[2]).to_be_visible()
+    expect(iframe_components[3]).not_to_be_visible()
+    expect(iframe_components[4]).not_to_be_visible()
+    expect(iframe_components[5]).not_to_be_visible()
+
+    tab1 = page.get_by_text('tab 1')
+    expect(tab1).to_be_visible()
+
+    tab2 = page.get_by_text('tab 2')
+    expect(tab2).to_be_visible()
+
+    # Tab 1
+    iframe_frame_0 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(0)
+    expect(iframe_frame_0.locator('div[id="pdfContainer"]')).to_be_visible()
+    expect(iframe_frame_0.locator('div[id="pdfViewer"]')).to_be_visible()
+
+    iframe_frame_1 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(1)
+    expect(iframe_frame_1.locator('div[id="pdfContainer"]')).to_be_visible()
+    expect(iframe_frame_1.locator('div[id="pdfViewer"]')).to_be_visible()
+
+    iframe_frame_2 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(2)
+    expect(iframe_frame_2.locator('div[id="pdfContainer"]')).to_be_visible()
+    expect(iframe_frame_2.locator('div[id="pdfViewer"]')).to_be_visible()
+
+    expect(iframe_components[0].locator('div[id="pdfViewer"]').get_by_text("from LaH10 to room–temperature").nth(
+        0)).to_be_hidden()
+    expect(iframe_components[1].locator('div[id="pdfViewer"]').get_by_text("from LaH10 to room–temperature").nth(
+        0)).to_be_hidden()
+    expect(iframe_components[2].locator('div[id="pdfViewer"]').get_by_text("from LaH10 to room–temperature").nth(
+        0)).to_be_hidden()
+
+    # click on the second tab and verify that the PDF is visible
+    tab2.click()
+
+    iframe_components = page.locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').all()
+    assert len(iframe_components) == 6
+
+    expect(iframe_components[0]).not_to_be_visible()
+    expect(iframe_components[1]).not_to_be_visible()
+    expect(iframe_components[2]).not_to_be_visible()
+    expect(iframe_components[3]).to_be_visible()
+    expect(iframe_components[4]).to_be_visible()
+    expect(iframe_components[5]).to_be_visible()
+
+    iframe_frame_3 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(3)
+    expect(iframe_frame_3.locator('div[id="pdfContainer"]')).to_be_visible()
+    expect(iframe_frame_3.locator('div[id="pdfViewer"]')).to_be_visible()
+
+    iframe_frame_4 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(4)
+    expect(iframe_frame_4.locator('div[id="pdfContainer"]')).to_be_visible()
+    expect(iframe_frame_4.locator('div[id="pdfViewer"]')).to_be_visible()
+
+    iframe_frame_5 = page.frame_locator('iframe[title="streamlit_pdf_viewer.streamlit_pdf_viewer"]').nth(5)
+    expect(iframe_frame_5.locator('div[id="pdfContainer"]')).to_be_visible()
+    expect(iframe_frame_5.locator('div[id="pdfViewer"]')).to_be_visible()
+
+    expect(iframe_frame_3.locator('div[id="pdfViewer"]').get_by_text("from LaH10 to room–temperature").nth(
+        0)).to_be_visible()
+    expect(iframe_frame_4.locator('div[id="pdfViewer"]').get_by_text("from LaH10 to room–temperature").nth(
+        0)).to_be_visible()
+    expect(iframe_frame_5.locator('div[id="pdfViewer"]').get_by_text("from LaH10 to room–temperature").nth(
+        0)).to_be_visible()


### PR DESCRIPTION
This PR attempts to improve the PDF resolution in the viewer, that, even if we are following the solution found in many places, it's not satisfying. 

We introduced a variable called `resolution_boost` that apply a boost on how the resolution is calculated. The value goes from 2 to 10, with default to 1. 
The canvas of the PDF pages is built by getting the Viewport (unscaled) and calculating the scaling ratio by dividing the expected width and the actual viewport width. 

When the canvas is created, we use the scaled viewport dimensions and we multiply by a ratio value due to the density of pixels of the device (given by `window.devicePixelRatio`), in the current version, this value is either 1 or 2 (retina displays).  

However, the quality of the PDF shown still is not optimal. 
So we added a boost ratio that will be a multiplied for the calculated ratio: 

```javascript
      const ratio = (window.devicePixelRatio || 1) * resolutionRatioBoost
```

this approach, gave acceptable results in our experiments. Nevertheless, we did not find any explanation and it might be used incorrectly. 

<img width="710" alt="image" src="https://github.com/user-attachments/assets/db7162d6-3e30-434c-b7ca-e7f0e4e03df6">



Higher ratio is definitely more resource-demanding on the browser, so use carefully, and, at your own risk :-)       
