### PR TITLE
Feature/configurable annotations border

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.22-dev0"
+current_version = "0.0.22-rc0"
 commit = "true"
 tag = "true"
 tag_name = "v{new_version}"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.0.21"
+current_version = "0.0.22-dev0"
 commit = "true"
 tag = "true"
 tag_name = "v{new_version}"

--- a/README.md
+++ b/README.md
@@ -88,10 +88,13 @@ Here an example:
       "y": 155,
       "height": 22,
       "width": 65,
-      "color": "red"
+      "color": "red",
+      "border": "solid"
    },
 [...]
 ```
+
+The `border` parameter can be set with the following values: `solid`, `dashed`, `dotted`, `double`, `groove`, `ridge`, `inset`, `outset`. Any other value will result in the default value: `solid`. 
 
 The example shown in our screenshot can be found [here](resources/annotations.json).
 
@@ -115,7 +118,8 @@ annotations = [
         "y": 155,
         "height": 22,
         "width": 65,
-        "color": "red"
+        "color": "red",
+        "border": "dotted"
     }
 ]
 

--- a/resources/annotations.json
+++ b/resources/annotations.json
@@ -6,7 +6,8 @@
     "width": "109.54",
     "height": "23.19",
     "color": "rgba(255, 0, 0, 0.4)",
-    "type": "title"
+    "type": "title",
+    "border": "dashed"
   },
   {
     "page": "1",

--- a/resources/annotations.sample.json
+++ b/resources/annotations.sample.json
@@ -5,7 +5,8 @@
     "y": 155,
     "height": 22,
     "width": 65,
-    "color": "red"
+    "color": "red",
+    "border": "dashed"
   },
   {
     "page": 1,

--- a/resources/annotations.sample.json
+++ b/resources/annotations.sample.json
@@ -22,6 +22,7 @@
     "y": 280,
     "height": 7,
     "width": 30,
-    "color": "orange"
+    "color": "orange",
+    "border": "groove"
   }
 ]

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -118,7 +118,11 @@ export default {
       annotationDiv.style.top = `${annotation.y * scale}px`;
       annotationDiv.style.width = `${annotation.width * scale}px`;
       annotationDiv.style.height = `${annotation.height * scale}px`;
-      annotationDiv.style.outline = `${props.args.annotation_outline_size * scale}px solid ${annotation.color}`;
+      let border = annotation.border
+      if (!annotation.border) {
+        border = "solid"
+      }
+      annotationDiv.style.outline = `${props.args.annotation_outline_size * scale}px ${border} ${annotation.color}`;
       annotationDiv.style.cursor = renderText ? 'text' : 'pointer';
       annotationDiv.style.pointerEvents = renderText ? 'none' : 'auto';
       annotationDiv.style.zIndex = 10;

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -29,6 +29,7 @@ import { debounce } from 'lodash';
 const CMAP_URL = "pdfjs-dist/cmaps/";
 const CMAP_PACKED = true;
 const ENABLE_XFA = true;
+const acceptedBorderStyleAttributes = ['solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset', 'none', undefined, null];
 
 export default {
   props: ["args"],
@@ -119,7 +120,7 @@ export default {
       annotationDiv.style.width = `${annotation.width * scale}px`;
       annotationDiv.style.height = `${annotation.height * scale}px`;
       let border = annotation.border
-      if (!annotation.border) {
+      if (!annotation.border || !acceptedBorderStyleAttributes.includes(annotation.border)) {
         border = "solid"
       }
       annotationDiv.style.outline = `${props.args.annotation_outline_size * scale}px ${border} ${annotation.color}`;


### PR DESCRIPTION
This PR adds the possibility to select the `border` style of the annotations. Adding `border`: `dashed` or `dotted` should show that on the application. 

This fixes #85 