### PR TITLE
refactor: Remove the use of index from the annotation object. If an annotation has an ID, use it; otherwise, generate the ID automatically.

### DIFF
--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -111,9 +111,9 @@ export default {
       return canvas;
     };
 
-    const renderAnnotation = (annotation, annotationIndex, pageDiv, scale) => {
+    const renderAnnotation = (annotation, pageDiv, scale) => {
       const annotationDiv = document.createElement('div');
-      annotationDiv.id = `annotation-${annotation.id || annotationIndex}`;
+      annotationDiv.id = `annotation-${annotation.id}`;
       annotationDiv.style.position = 'absolute';
       annotationDiv.style.left = `${annotation.x * scale}px`;
       annotationDiv.style.top = `${annotation.y * scale}px`;
@@ -131,7 +131,7 @@ export default {
       if (!renderText) {
         annotationDiv.addEventListener('click', () => {
           Streamlit.setComponentValue({
-            clicked_annotation: { index: annotationIndex, ...annotation },
+            clicked_annotation: annotation,
           });
         });
       }
@@ -186,8 +186,10 @@ export default {
 
       if (annotations && annotations.length > 0) {
         annotations.forEach((annotation, index) => {
-          const annotationUniqueIndex = annotationCount + index
-          renderAnnotation(annotation, annotationUniqueIndex, pageDiv, viewport.scale);
+          if (!annotation.id) {
+            annotation.id = annotationCount + index;
+          }
+          renderAnnotation(annotation, pageDiv, viewport.scale);
         });
       }
 

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -131,7 +131,7 @@ export default {
       if (!renderText) {
         annotationDiv.addEventListener('click', () => {
           Streamlit.setComponentValue({
-            clicked_annotation: annotation,
+            clicked_annotation: {...annotation},
           });
         });
       }

--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -131,7 +131,7 @@ export default {
       if (!renderText) {
         annotationDiv.addEventListener('click', () => {
           Streamlit.setComponentValue({
-            clicked_annotation: { index: annotation.index, ...annotation },
+            clicked_annotation: { index: annotationIndex, ...annotation },
           });
         });
       }


### PR DESCRIPTION
To support this requirement https://github.com/lfoppiano/streamlit-pdf-viewer/issues/92#issuecomment-2829400323

