### PR TITLE
fix: pages_vertical_spacing is not working #98

### DIFF
--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -100,12 +100,11 @@ export default {
 
       const canvas = document.createElement("canvas");
       canvas.id = `canvas_page_${pageNumber}`;
-      canvas.height = viewport.height * ratio + props.args.pages_vertical_spacing;
+      canvas.height = viewport.height * ratio;
       canvas.width = viewport.width * ratio;
       canvas.style.width = `${viewport.width}px`;
       canvas.style.height = `${viewport.height}px`;
       canvas.style.display = "block";
-      canvas.style.marginBottom = `${props.args.pages_vertical_spacing}px`;
       canvas.getContext("2d").scale(ratio, ratio);
 
       return canvas;
@@ -154,6 +153,7 @@ export default {
       pageDiv.style.position = 'relative';
       pageDiv.style.width = `${viewport.width}px`;
       pageDiv.style.height = `${viewport.height}px`;
+      pageDiv.style.marginBottom = `${props.args.pages_vertical_spacing}px`;
 
       const canvasWrapper = document.createElement('div');
       canvasWrapper.className = 'canvasWrapper';


### PR DESCRIPTION
From the issue #98 

## Cause

The margin-bottom was applied to the child canvas element, but this did not apply margin-bottom to the parent div element with the page class.

I suspect this issue started occurring when the PDF resolution enhancement feature (https://github.com/lfoppiano/streamlit-pdf-viewer/pull/49/ , https://github.com/lfoppiano/streamlit-pdf-viewer/pull/64) was added, but due to differences in pdf.js versions and multiple refactoring efforts, it would have taken considerable time to reproduce the issue. Thus, I was unable to identify the specific commit that caused the problem.

## Fix

Applied margin-bottom to the parent div element with the page class instead.

## Range of effect

I'm guessing all browsers has this problem. (Chrome, Brave, Safari, Firefox at least)

## Test

Using latest main branch of https://github.com/lfoppiano/structure-vision
cf6a8640e2d3878ddb481a41a617c86b9ad28f12


