### PR TITLE
Fix annotations type in method definition

### DIFF
--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -30,7 +30,7 @@ def pdf_viewer(
         width: Union[str, int] = None,
         height: int = None,
         key=None,
-        annotations: List[Dict[str, Union[str, int, float, bool]]] = (),
+        annotations: List[Dict[str, Union[str, int, float, bool]]] = [],
         pages_vertical_spacing: int = 2,
         annotation_outline_size: int = 1,
         rendering: str = RENDERING_UNWRAP,


### PR DESCRIPTION
Fixed the method definition for the annotations parameter, which would lead to "TypeError("annotations must be a list of dictionaries")" if no annotations where passed.

