### PR TITLE
Restore the scrolling-container parent div

### DIFF
--- a/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
+++ b/streamlit_pdf_viewer/frontend/src/PdfViewer.vue
@@ -1,6 +1,8 @@
 <template>
   <div :style="pdfContainerStyle" ref="pdfContainer" class="container-wrapper">
-    <div id="pdfViewer"></div>
+    <div class="scrolling-container">
+      <div id="pdfViewer"></div>
+    </div>
     <div class="zoom-controls">
       <button class="zoom-button" @click.stop="toggleZoomPanel">
         {{ Math.round(currentZoom * 100) }}%


### PR DESCRIPTION
The scroll-bar was not shown in the latest main version because the `scrolling-container` surrounding the `#pdfViewer` div had also been mistakenly removed in #96 

This PR restores it.