### PR TITLE
Add information about streamlit limits against #107

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Here are some caveats to be aware of:
     - If you need to use all the available space and limit the height, you can encapsulate the `pdf_viewer()` into a
       `st.component(width:...)` setting the width.
 - The `legacy` rendering has been removed from version 0.1.x+
+
+## Streamlit compatibility
+
+Streamlit ≥ 1.41 has a regression in custom-component iframe handling that can reset the page
+scroll position after an `st.dialog` is closed — see issue
+[#107](https://github.com/lfoppiano/streamlit-pdf-viewer/issues/107) for details and the bisect
+data. The last fully working Streamlit version in our testing is 1.40.2.
+
+If this regression affects your app, pin `streamlit<1.41` in your requirements. A runtime
+`UserWarning` is emitted at import time whenever a newer Streamlit is detected.
+
 ## Getting started
 
 ```sh

--- a/streamlit_pdf_viewer/__init__.py
+++ b/streamlit_pdf_viewer/__init__.py
@@ -6,6 +6,27 @@ from typing import Union, List, Optional, Callable, Dict
 import streamlit.components.v1 as components
 import json
 
+# Streamlit >= 1.41 introduced a regression in custom-component iframe handling
+# that resets the page scroll position after an st.dialog is closed (see
+# https://github.com/lfoppiano/streamlit-pdf-viewer/issues/107). Surface this to
+# users at import time so it's visible without reading release notes.
+try:
+    import warnings as _warnings
+    import streamlit as _st
+    from packaging.version import Version as _V
+
+    if _V(_st.__version__) >= _V("1.41.0"):
+        _warnings.warn(
+            "streamlit-pdf-viewer: Streamlit >= 1.41 has a known regression "
+            "that may reset the page scroll after an st.dialog is closed. "
+            "See https://github.com/lfoppiano/streamlit-pdf-viewer/issues/107 . "
+            "Pin streamlit<1.41 if this affects your app.",
+            UserWarning,
+            stacklevel=2,
+        )
+except Exception:
+    pass
+
 _RELEASE = True
 
 if not _RELEASE:


### PR DESCRIPTION
This PR informs uses about the latest streamlit version to be used to avoid #107. The version is no enforced because #107 only occur on specific conditions. 